### PR TITLE
Add options and logic to handle scaled resolution minimum values

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -23,6 +23,8 @@ function loadPrefs(callback) {
 		curLeft: true,
 		curTop: true,
 		minWidth: 0,
-		minHeight: 0
+		minHeight: 0,
+		minScaledWidth: 0,
+		minScaledHeight: 0
 	}, callback);
 }

--- a/imgdata.js
+++ b/imgdata.js
@@ -83,6 +83,11 @@ function imgHover(event) {
 	if(event.target.naturalWidth < prefs.minWidth || event.target.naturalHeight < prefs.minHeight) {
 		displayData(false);
 		return;
+    }
+	//hide if the scaled img is smaller than minimum
+	if(event.target.width < prefs.minScaledWidth || event.target.height < prefs.minScaledHeight) {
+		displayData(false);
+		return;
 	}
 	//dont change display incase mouse left img before onload
 	if(event.type !== 'load')

--- a/options.html
+++ b/options.html
@@ -50,6 +50,10 @@
 		<label title="Images smaller than this size will not show image data">
 			<div class="fixedWidth"><input id="minWidth" type="number"> &times; <input id="minHeight" type="number"></div>
 			<span>Minimum resolution</span>
+        </label>
+		<label title="Images shown to be smaller than this size will not show image data">
+			<div class="fixedWidth"><input id="minScaledWidth" type="number"> &times; <input id="minScaledHeight" type="number"></div>
+			<span>Minimum scaled resolution</span>
 		</label>
 		<label title="When using the follow cursor or tooltip positioning, How far the image data div should be offset from the cursor in pixels, on the X and Y axes. Negative values move in the opposite direction.">
 			<div class="fixedWidth"><input id="offX" type="number"> &times; <input id="offY" type="number"></div>

--- a/options.js
+++ b/options.js
@@ -90,7 +90,9 @@ function setPrefs(storage) {
 	document.getElementById('alt').checked = storage.alt;
 	document.getElementById('scale').checked = storage.scale;
 	document.getElementById('minWidth').value = storage.minWidth;
-	document.getElementById('minHeight').value = storage.minHeight;
+    document.getElementById('minHeight').value = storage.minHeight;
+    document.getElementById('minScaledWidth').value = storage.minScaledWidth;
+	document.getElementById('minScaledHeight').value = storage.minScaledHeight;
 	document.getElementById('offX').value = storage.offX;
 	document.getElementById('offY').value = storage.offY;
 
@@ -125,6 +127,8 @@ document.getElementById('alt').addEventListener('change', saveChecked);
 document.getElementById('scale').addEventListener('change', saveChecked);
 document.getElementById('minWidth').addEventListener('input', saveNumber);
 document.getElementById('minHeight').addEventListener('input', saveNumber);
+document.getElementById('minScaledWidth').addEventListener('input', saveNumber);
+document.getElementById('minScaledHeight').addEventListener('input', saveNumber);
 document.getElementById('offX').addEventListener('input', saveNumber);
 document.getElementById('offY').addEventListener('input', saveNumber);
 //options updating the page


### PR DESCRIPTION
Hello @aridacity 
Thanks for this little nice extension!

I found a couple websites that uses pretty big images greatly down-scaled as icons, so even if I set the minimum height and width options at a reasonable value, the popup blinks when passing over those tiny images.

In this PR I add the option to set the scaled minimum sized allowed, so that a little image is treated as little, no matter it's original resolution.

Hoping it's ok for you,
Thanks